### PR TITLE
Fix/workflow tests

### DIFF
--- a/.github/workflows/component_test.yml
+++ b/.github/workflows/component_test.yml
@@ -10,23 +10,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache emuladores firebase
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/firebase/emulators
           key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
-
+          restore-keys: |
+            ${{ runner.os }}-firebase-emulators-
       - run: npm install -g firebase-tools
-
       - uses: jsdaniell/create-json@v1.2.3
         name: Criar json
         with:
           name: serviceAccountKey.json
           json: ${{ secrets.SERVICE_ACCOUNT_KEY }}
 
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Emulator
-        run: npm run em:start
       - name: Cypress run
         uses: cypress-io/github-action@v6.5.0
         with:

--- a/.github/workflows/component_test.yml
+++ b/.github/workflows/component_test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/firebase/emulators
-          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
+          key: ${{ runner.os }}-firebase-emulators-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-firebase-emulators-
       - run: npm install -g firebase-tools

--- a/.github/workflows/component_test.yml
+++ b/.github/workflows/component_test.yml
@@ -3,16 +3,68 @@ on:
   push:
 
 jobs:
+  #build dos emuladores
   cypress-run:
     runs-on: ubuntu-22.04
     environment: staging
     steps:
+      - uses: actions/checkout@v4
+      - name: Cache emuladores firebase
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/firebase/emulators
+          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
+
+      - run: npm install -g firebase-tools
+
+      - uses: jsdaniell/create-json@v1.2.3
+        name: Criar json
+        with:
+          name: serviceAccountKey.json
+          json: ${{ secrets.SERVICE_ACCOUNT_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Emulator
+        run: npm run em:start
       - name: Cypress run
         uses: cypress-io/github-action@v6.5.0
         with:
-          build: npm run build
-          start: npm run preview
+          #inicializando servidor de desenvolvimento junto dos emuladores
+          start: npm run em:dev
+          #servidor de desenvolvimento deve estar pronto antes de rodar os testes
+          wait-on: "http://localhost:5173"
           browser: chrome
           component: true
+        env:
+          # token de acesso a cli do firebase
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
+          # token usado para diferenciar uma nova run de uma repetida
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          # variaveis com prefixo cypress são usadas pela sdk de administrador
+          VITE_FIREBASE_API_KEY: ${{secrets.VITE_FIREBASE_API_KEY}}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{secrets.VITE_FIREBASE_AUTH_DOMAIN}}
+          VITE_FIREBASE_PROJECT_ID: ${{secrets.VITE_FIREBASE_PROJECT_ID}}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{secrets.VITE_FIREBASE_STORAGE_BUCKET}}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.VITE_FIREBASE_MESSAGING_SENDER_ID}}
+          VITE_FIREBASE_APP_ID: ${{secrets.VITE_FIREBASE_APP_ID}}
+
+          CYPRESS_VITE_FIREBASE_API_KEY: ${{secrets.VITE_FIREBASE_API_KEY}}
+          CYPRESS_VITE_FIREBASE_AUTH_DOMAIN: ${{secrets.VITE_FIREBASE_AUTH_DOMAIN}}
+          CYPRESS_VITE_FIREBASE_PROJECT_ID: ${{secrets.VITE_FIREBASE_PROJECT_ID}}
+          CYPRESS_VITE_FIREBASE_STORAGE_BUCKET: ${{secrets.VITE_FIREBASE_STORAGE_BUCKET}}
+          CYPRESS_VITE_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.VITE_FIREBASE_MESSAGING_SENDER_ID}}
+          CYPRESS_VITE_FIREBASE_APP_ID: ${{secrets.VITE_FIREBASE_APP_ID}}
+
+          #portas dos emuladores
+          FIRESTORE_EMULATOR_HOST: "localhost:8080"
+          FIREBASE_AUTH_EMULATOR_HOST: "localhost:9099"
+          FIREBASE_STORAGE_EMULATOR_HOST=: "localhost:9199"
+
+          CYPRESS_FIRESTORE_EMULATOR_HOST: "localhost:8080"
+          CYPRESS_FIREBASE_AUTH_EMULATOR_HOST: "localhost:9099"
+          CYPRESS_FIREBASE_STORAGE_EMULATOR_HOST=: "localhost:9199"
+
+          #UID reutilizado para testes
+          CYPRESS_TEST_UID: "U6gIZIQ9FCZ7aBjBig6pWobYuEg7"

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -16,6 +16,12 @@ jobs:
 
       - run: npm install -g firebase-tools
 
+      - uses: jsdaniell/create-json@v1.2.3
+        name: Criar json
+        with:
+          name: serviceAccountKey.json
+          json: ${{ secrets.SERVICE_ACCOUNT_KEY }}
+
       - uses: cypress-io/github-action@v6
         name: Cypress run
         with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -7,13 +7,39 @@ jobs:
     environment: staging
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      # Install npm dependencies, cache them correctly
-      # and run all Cypress tests
-      - name: Cypress run
-        uses: cypress-io/github-action@v6
+      - uses: actions/checkout@v4
+      - name: Cache emuladores firebase
+        uses: actions/cache@v2
         with:
-          #inicializando servidor de desenvolvimento
-          start: npm run dev
+          path: ~/.cache/firebase/emulators
+          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
+
+      - run: npm install -g firebase-tools
+
+      - uses: cypress-io/github-action@v6
+        name: Cypress run
+        with:
+          #inicializando servidor de desenvolvimento junto dos emuladores
+          start: npm run em:dev
           browser: chrome
+        env:
+          # token de acesso a cli do firebase
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
+          # token usado para diferenciar uma nova run de uma repetida
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          # necessario para inicializar app firebase com sdk de administrador
+          VITE_FIREBASE_API_KEY: ${{secrets.VITE_FIREBASE_API_KEY}}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{secrets.VITE_FIREBASE_AUTH_DOMAIN}}
+          VITE_FIREBASE_PROJECT_ID: ${{secrets.VITE_FIREBASE_PROJECT_ID}}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{secrets.VITE_FIREBASE_STORAGE_BUCKET}}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.VITE_FIREBASE_MESSAGING_SENDER_ID}}
+          VITE_FIREBASE_APP_ID: ${{secrets.VITE_FIREBASE_APP_ID}}
+
+          #portas dos emuladores
+          FIRESTORE_EMULATOR_HOST: "localhost:8080"
+          FIREBASE_AUTH_EMULATOR_HOST: "localhost:9099"
+          FIREBASE_STORAGE_EMULATOR_HOST=: "localhost:9199"
+
+          #UID reutilizado para testes
+          TEST_UID: "U6gIZIQ9FCZ7aBjBig6pWobYuEg7"

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -9,13 +9,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache emuladores firebase
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/firebase/emulators
           key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
-
+          restore-keys: |
+            ${{ runner.os }}-firebase-emulators-
       - run: npm install -g firebase-tools
-
       - uses: jsdaniell/create-json@v1.2.3
         name: Criar json
         with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -36,7 +36,7 @@ jobs:
 
           # token usado para diferenciar uma nova run de uma repetida
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          # necessario para inicializar app firebase com sdk de administrador
+          # variaveis com prefixo cypress são usadas pela sdk de administrador
           VITE_FIREBASE_API_KEY: ${{secrets.VITE_FIREBASE_API_KEY}}
           VITE_FIREBASE_AUTH_DOMAIN: ${{secrets.VITE_FIREBASE_AUTH_DOMAIN}}
           VITE_FIREBASE_PROJECT_ID: ${{secrets.VITE_FIREBASE_PROJECT_ID}}
@@ -44,10 +44,21 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.VITE_FIREBASE_MESSAGING_SENDER_ID}}
           VITE_FIREBASE_APP_ID: ${{secrets.VITE_FIREBASE_APP_ID}}
 
+          CYPRESS_VITE_FIREBASE_API_KEY: ${{secrets.VITE_FIREBASE_API_KEY}}
+          CYPRESS_VITE_FIREBASE_AUTH_DOMAIN: ${{secrets.VITE_FIREBASE_AUTH_DOMAIN}}
+          CYPRESS_VITE_FIREBASE_PROJECT_ID: ${{secrets.VITE_FIREBASE_PROJECT_ID}}
+          CYPRESS_VITE_FIREBASE_STORAGE_BUCKET: ${{secrets.VITE_FIREBASE_STORAGE_BUCKET}}
+          CYPRESS_VITE_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.VITE_FIREBASE_MESSAGING_SENDER_ID}}
+          CYPRESS_VITE_FIREBASE_APP_ID: ${{secrets.VITE_FIREBASE_APP_ID}}
+
           #portas dos emuladores
           FIRESTORE_EMULATOR_HOST: "localhost:8080"
           FIREBASE_AUTH_EMULATOR_HOST: "localhost:9099"
           FIREBASE_STORAGE_EMULATOR_HOST=: "localhost:9199"
 
+          CYPRESS_FIRESTORE_EMULATOR_HOST: "localhost:8080"
+          CYPRESS_FIREBASE_AUTH_EMULATOR_HOST: "localhost:9099"
+          CYPRESS_FIREBASE_STORAGE_EMULATOR_HOST=: "localhost:9199"
+
           #UID reutilizado para testes
-          TEST_UID: "U6gIZIQ9FCZ7aBjBig6pWobYuEg7"
+          CYPRESS_TEST_UID: "U6gIZIQ9FCZ7aBjBig6pWobYuEg7"

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/firebase/emulators
-          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
+          key: ${{ runner.os }}-firebase-emulators-${{ github.sha}}
           restore-keys: |
             ${{ runner.os }}-firebase-emulators-
       - run: npm install -g firebase-tools

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           #inicializando servidor de desenvolvimento junto dos emuladores
           start: npm run em:dev
+          #servidor de desenvolvimento deve estar pronto antes de rodar os testes
+          wait-on: "http://localhost:5173"
           browser: chrome
         env:
           # token de acesso a cli do firebase

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cypress:run": "cypress run",
     "cypress:open": "cypress open",
     "em:start": "firebase emulators:start --import ./emulator_data",
+    "em:dev": "firebase emulators:exec --import ./emulator_data  \"npm run dev\"",
     "test": "npx concurrently \"npm run em:start\" \"npm run cypress:open\""
   },
   "dependencies": {

--- a/src/components/GoogleLoginButton/__tests__/GoogleLoginButton.test.tsx
+++ b/src/components/GoogleLoginButton/__tests__/GoogleLoginButton.test.tsx
@@ -1,21 +1,22 @@
 import GoogleLoginButton from "../GoogleLoginButton"
 import getDesignTokens from "../../../theme/theme"
 import { ThemeProvider } from "@emotion/react"
-import {loginMethods} from "../../../Utils/loginGoogle"
+import { loginMethods } from "../../../Utils/loginGoogle"
 
 const theme = getDesignTokens('light')
 
 describe("Testando o componente GoogleLoginButton", () => {
-    it("renderiza corretamente", () => {
-        cy.mount(<ThemeProvider theme={theme}><GoogleLoginButton data-class-ref='button' /></ThemeProvider>)
-        cy.get("[data-cy='botaoLoginGoogle']").should('exist')
-    })
+  it("renderiza corretamente", () => {
+    cy.mount(<ThemeProvider theme={theme}><GoogleLoginButton data-class-ref='button' /></ThemeProvider>)
+    cy.get("[data-cy='botaoLoginGoogle']").should('exist')
+  })
 
-    it("Checa se a função é chamada", () => {
-        cy.mount(<ThemeProvider theme={theme}><GoogleLoginButton data-class-ref='button' /></ThemeProvider>)
-        cy.spy(loginMethods, 'loginGoogle')
-        cy.get("[data-cy='botaoLoginGoogle']").click().then(() => {
-            expect(loginMethods.loginGoogle).to.be.called  
-        })
+  it("Checa se a função é chamada", () => {
+    cy.mount(<ThemeProvider theme={theme}><GoogleLoginButton data-class-ref='button' /></ThemeProvider>)
+    cy.spy(loginMethods, 'loginGoogle')
+    throw new Error("Broken test")
+    cy.get("[data-cy='botaoLoginGoogle']").click().then(() => {
+      expect(loginMethods.loginGoogle).to.be.called
     })
+  })
 })


### PR DESCRIPTION
# Fix Workflow de testes

## Resolve
#57 

## Descrição 
Alterando workflows de testes automatizados para conectarem-se ao emulador do firebase

## Adições

- Adicionando variáveis de ambiente do firebase e dos emuladores nos dois workflows
- Adicionando etapa para realizar cache dos emuladores do firebase
- Adicionando etapa para escrever arquivo serviceAccountKey.json
- Adicionando wait-on para que o cypress aguarde o servidor de desenvolvimento
- Adicionando comando para executar emulador e servidor de desenvolvimento simultaneamente

## Alterações

- testes de componente não executam mais o servidor de produção
- Lançando erro no segundo teste do login com google

## Remoções

- Removendo etapa build no job Cypress

## Verificando
- [ ] Testes de componente e testes ponta a ponta utilizam o emulador
- [ ] Nenhuma dado adicionado no console do ambiente de staging