### PR TITLE
feat/info-section

### DIFF
--- a/src/components/InfoSection/InfoSection.tsx
+++ b/src/components/InfoSection/InfoSection.tsx
@@ -1,0 +1,368 @@
+import CloseIcon from '@mui/icons-material/Close';
+import EditIcon from '@mui/icons-material/Edit';
+import styled from "@mui/material/styles/styled";
+import useTheme from "@mui/material/styles/useTheme";
+import { Theme } from "@mui/material/styles/createTheme";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import Button from "@mui/material/Button"
+import { ButtonBaseProps } from "@mui/material/ButtonBase";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import Dialog from "@mui/material/Dialog"
+import DialogActions from "@mui/material/DialogActions"
+import DialogContent from "@mui/material/DialogContent"
+import DialogContentText from "@mui/material/DialogContentText"
+import Skeleton from "@mui/material/Skeleton";
+
+import { useEffect, useState } from "react";
+import { SubmitHandler } from "react-hook-form";
+import { auth } from "../../../firebase/firebase";
+import useInfoMuseuForm from "../../hooks/useInfoMuseuForm";
+import { InfoMuseu } from "../../interfaces/InfoMuseu";
+import useInfoMuseu from './useInfoMuseu';
+
+interface InfoSectionProps {
+  id: string
+}
+
+
+const InfoSection = ({ id }: InfoSectionProps) => {
+  const theme = useTheme()
+  const mobile = useMediaQuery(theme.breakpoints.down('sm'))
+
+  const [editable, setEditable] = useState<boolean>(false)
+  const [editing, setEditing] = useState<boolean>(false)
+
+  const { status, infoMuseu, atualizarInfoMuseu } = useInfoMuseu(id)
+
+  const [showDialog, setShowDialog] = useState<boolean>(false)
+  const [dialogMessage, setDialogMessage] = useState<string>('')
+
+  useEffect(() => {
+    auth.onAuthStateChanged(user => {
+      if (user) {
+        setEditable(true)
+      }
+    })
+  }, [])
+
+  const { handleSubmit, register, formState, watch, setValue } = useInfoMuseuForm(infoMuseu ? infoMuseu : { nome: '', texto: '' }, status)
+  const { isSubmitting } = formState
+  const currentImage = watch('imagem')
+
+  const loadSrc = (src: File | string | undefined): string => {
+    if (typeof (src) == 'string') {
+      return src
+    }
+    else if (src instanceof File) {
+      return URL.createObjectURL(src)
+    }
+    else {
+      return ''
+    }
+  }
+
+  const submitForm: SubmitHandler<InfoMuseu> = async (data: InfoMuseu) => {
+    if (data?.imagem?.src === undefined) {
+      // atualiza apenas o texto e o nome se nenhuma imagem for selecionada
+      delete data.imagem
+    }
+    await atualizarInfoMuseu(data).then(() => {
+      setDialogMessage('Informação atualizada com sucesso')
+      setEditing(false)
+      // todos os outros campos são atualizados com o listener onSnapshot,
+      // mas o firebase storage não suporta listeners. Por isso, quando os metadados são alterados
+      // é preciso atualizá-los manualmente
+      if (dirtyAltText()) {
+        const updatedAlt = data?.imagem?.alt ?? ''
+        if (infoMuseu && infoMuseu.imagem) {
+          infoMuseu.imagem.alt = updatedAlt
+        }
+      }
+    }).catch((error) => {
+      setDialogMessage(`Erro ao atualizar informação \n ${error.message}`)
+    }).finally(() => {
+      setShowDialog(true)
+    }
+    )
+  }
+  const dirtyAltText = (): boolean => {
+    return infoMuseu?.imagem?.alt !== currentImage?.alt
+  }
+
+  if (status === 'error') {
+    return <InfoSectionContainer style={{
+      height: 200,
+      alignItems: 'center',
+      background: theme.palette.grey[200]
+    }}>
+      <Typography variant='headlineSmall' data-cy='info-error-title'>
+        Erro ao carregar informação
+      </Typography>
+    </InfoSectionContainer>
+  }
+
+  if (status === 'loading') {
+    return <InfoSectionContainer style={{
+      height: 200,
+      alignItems: 'center',
+      background: theme.palette.grey[200]
+    }}>
+      <InfoSectionText>
+        <InfoSectionHeader>
+          <Skeleton variant='text' sx={{
+            width: '50%',
+            height: 50
+          }}
+          />
+        </InfoSectionHeader>
+        <Skeleton variant='text' sx={{
+          width: '100%',
+          height: 100
+        }} />
+      </InfoSectionText>
+      <InfoImageContainer>
+        <Skeleton variant='rectangular' sx={{
+          width: 150,
+          height: 150
+        }} />
+      </InfoImageContainer>
+    </InfoSectionContainer>
+  }
+
+  return (
+    <InfoSectionContainer>
+      {!editing ?
+        <>
+          <InfoSectionText>
+            <InfoSectionHeader>
+              <Typography variant='displayMedium' data-cy='info-title'>{infoMuseu?.nome}</Typography>
+              {editable && <InfoSectionEditButton
+                component='label'
+                variant='contained'
+                onClick={() => { setEditing(true); }}
+                data-cy='info-edit-button'>
+                <EditIcon />
+              </InfoSectionEditButton>}
+            </InfoSectionHeader>
+            <Typography variant='bodyLarge' data-cy='info-text'>{infoMuseu?.texto}</Typography>
+          </InfoSectionText>
+          <InfoImageContainer>
+            <figure>
+              <img
+                src={loadSrc(infoMuseu?.imagem?.src)}
+                alt={infoMuseu?.imagem?.alt}
+                data-cy='info-image' />
+              <figcaption style={{ textAlign: 'center' }} data-cy='info-alt-text'>{infoMuseu?.imagem?.alt}</figcaption>
+            </figure>
+          </InfoImageContainer>
+        </>
+        :
+        // estado de edicao do componente
+        <form onSubmit={handleSubmit(submitForm)} style={{
+          width: '100%',
+          display: 'flex',
+          alignContent: 'center',
+          justifyContent: 'center',
+          flexDirection: mobile ? 'column-reverse' : 'row',
+          gap: theme.spacing(2),
+        }}>
+          <InfoSectionText>
+            <InfoSectionHeader>
+              <TextField
+                sx={{
+                  maxWidth: 260
+                }}
+
+                {...register('nome', { required: "Título da seção é obrigatório" })}
+                label='Título da seção'
+                error={formState.errors.nome ? true : false}
+                helperText={formState.errors.nome ? formState.errors.nome.message : ''}
+                variant='filled'
+                data-cy='info-edit-title-field'
+              />
+            </InfoSectionHeader>
+            <TextField
+              sx={{
+                maxWidth: 650
+              }}
+              {...register('texto', { required: "Texto não pode ser vazio" })}
+              label='Descrição'
+              multiline
+              error={formState.errors.texto ? true : false}
+              helperText={formState.errors.texto ? formState.errors.texto.message : ''}
+              variant='filled'
+              data-cy='info-edit-text-field'
+            />
+            <InfoEditOptions>
+              <Button sx={{
+                textTransform: 'initial',
+                background: theme.palette.primary.main,
+                color: theme.palette.onPrimary.main
+              }}
+                type='submit'
+                variant='contained'
+                disabled={isSubmitting}
+                data-cy='info-submit-button'>
+                {
+                  isSubmitting ? 'Salvando' : 'Salvar'
+                }
+              </Button>
+              <Button sx={{
+                textTransform: 'initial',
+                background: theme.palette.secondary.main,
+                color: theme.palette.onSecondary.main
+              }}
+                type='reset'
+                variant='contained'
+                onClick={() => { setEditing(false); }}
+                data-cy='info-cancel-button'>
+                Cancelar
+              </Button>
+            </InfoEditOptions>
+          </InfoSectionText>
+          <InfoImageContainer>
+            {currentImage &&
+              <>
+                <figure style={{ margin: 'auto', position: 'relative' }}>
+
+                  <InfoImageRemoveButton
+                    component='span'
+                    onClick={() => {
+                      setValue('imagem', undefined)
+                    }}
+                    data-cy='info-image-remove-button'
+                  >
+                    <CloseIcon />
+                  </InfoImageRemoveButton>
+                  <img
+                    style={{ position: 'relative' }}
+                    // imagem renderizada durante a edicao é a imagem atual do conteúdo
+                    // ou a imagem selecionada no input
+                    src={loadSrc(currentImage.src)}
+                    alt={currentImage.alt}
+                    data-cy='info-image' />
+                  <figcaption style={{ textAlign: 'center' }} data-cy='info-image-alt-text'>{currentImage.alt}</figcaption>
+                </figure>
+                <TextField
+                  {...register('imagem.alt')}
+                  label='Texto alternativo da imagem'
+                  variant='filled'
+                  data-cy='info-image-alt-field'
+                />
+              </>
+            }
+            <Button
+              component='label'
+              variant='contained'
+              sx={{
+                textTransform: 'initial',
+                background: theme.palette.tertiary.main,
+                color: theme.palette.onTertiary.main
+              }}
+              data-cy='info-image-button'
+            >
+              {currentImage ? "Alterar imagem" : "Adicionar imagem"}
+              <input
+                type='file'
+                accept="image/*"
+                onChange={(e) => { if (e.target.files) setValue('imagem.src', e.target.files?.[0]) }}
+                id="image-upload-input"
+                hidden />
+            </Button>
+          </InfoImageContainer>
+        </form>
+      }
+      <Dialog
+        open={showDialog}
+        onClose={() => setShowDialog(false)}
+        data-cy-info-update-dialog>
+        <DialogContent>
+          <DialogContentText style={{ whiteSpace: 'pre-line' }} data-cy-info-update-dialog-text>
+            {dialogMessage}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowDialog(false)}>Fechar</Button>
+        </DialogActions>
+      </Dialog>
+    </InfoSectionContainer >
+
+  );
+}
+
+const InfoSectionContainer = styled('section')(({ theme }: { theme: Theme }) => ({
+  display: 'flex',
+  alignSelf: 'stretch',
+  alignContent: 'center',
+  justifyContent: 'center',
+  padding: `${theme.spacing(1)} ${theme.spacing(1)}`,
+  gap: theme.spacing(2),
+  button: {
+    borderRadius: '1rem',
+    padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+  },
+  img: {
+    maxWidth: 350,
+    maxHeight: 350,
+  },
+  '@media screen and (max-width: 600px)': {
+    flexDirection: 'column-reverse',
+    img: {
+      maxWidth: 250,
+      maxHeight: 250,
+    }
+  },
+}))
+
+const InfoSectionHeader = styled('div')(({ theme }: { theme: Theme }) => ({
+  display: 'flex',
+  alignSelf: 'stretch',
+  alignItems: 'center',
+  gap: theme.spacing(2),
+  color: theme.palette.onSurfaceVariant.main,
+}))
+
+const InfoSectionEditButton = styled(Button)<ButtonBaseProps>(({ theme }: { theme: Theme }) => ({
+  maxHeight: theme.spacing(4),
+  backgroundColor: theme.palette.primary.main,
+  color: theme.palette.onPrimary.main,
+  padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+  borderRadius: '1rem',
+  minWidth: 32,
+}))
+
+const InfoSectionText = styled('div')(({ theme }: { theme: Theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  color: theme.palette.onSurface.main,
+  gap: theme.spacing(2),
+}))
+
+const InfoEditOptions = styled('div')(({ theme }: { theme: Theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(3),
+}))
+
+const InfoImageContainer = styled('div')(({ theme }: { theme: Theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+}))
+
+const InfoImageRemoveButton = styled(Button)<ButtonBaseProps>(({ theme }: { theme: Theme }) => ({
+  backgroundColor: theme.palette.error.main,
+  color: theme.palette.onError.main,
+  borderRadius: '20%',
+  minWidth: 24,
+  maxWidth: 24,
+  position: 'absolute',
+  zIndex: 1,
+  top: theme.spacing(0),
+  right: 0,
+  padding: 0
+}))
+export default InfoSection;

--- a/src/components/InfoSection/InfoSection.tsx
+++ b/src/components/InfoSection/InfoSection.tsx
@@ -254,6 +254,7 @@ const InfoSection = ({ id }: InfoSectionProps) => {
             }
             <Button
               component='label'
+              id='image-upload-button'
               variant='contained'
               sx={{
                 textTransform: 'initial',
@@ -265,6 +266,7 @@ const InfoSection = ({ id }: InfoSectionProps) => {
               {currentImage ? "Alterar imagem" : "Adicionar imagem"}
               <input
                 type='file'
+                aria-labelledby='image-upload-button'
                 accept="image/*"
                 onChange={(e) => { if (e.target.files) setValue('imagem.src', e.target.files?.[0]) }}
                 id="image-upload-input"

--- a/src/components/InfoSection/__tests__/InfoSection.test.tsx
+++ b/src/components/InfoSection/__tests__/InfoSection.test.tsx
@@ -1,0 +1,265 @@
+import { ThemeProvider, createTheme } from "@mui/material"
+import { auth } from "../../../../firebase/firebase"
+import { adicionarInfoMuseu } from "../../../Utils/infoMuseuFirebase"
+import getDesignTokens from "../../../theme/theme"
+import InfoSection from "../InfoSection"
+
+const theme = createTheme(getDesignTokens('light'))
+const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
+
+Cypress.on('uncaught:exception', (err) => {
+  if (resizeObserverLoopErrRe.test(err.message)) {
+    return false
+  }
+})
+
+// adicionando dados de teste programaticamente em cada conjunto de testes
+const addInfoWithImage = async (imagemBase64: string): Promise<string> => {
+  let id = ""
+  //convertendo base64 para File
+  const response = await fetch(`data:image/jpeg;base64,${imagemBase64}`);
+  const file = new File([await response.blob()], "default_image.png", { type: "image/png" });
+  const infoComImagem = {
+    nome: "Teste",
+    texto: "Teste",
+    imagem: {
+      src: file,
+      alt: "",
+      title: "",
+    }
+  }
+  id = await adicionarInfoMuseu(infoComImagem)
+  return id
+}
+
+const addInfoWithoutImage = async (): Promise<string> => {
+  const infoSemImagem = {
+    nome: "Teste",
+    texto: "Teste",
+  }
+  const id = await adicionarInfoMuseu(infoSemImagem)
+  return id
+}
+
+describe("Testando componente InfoSection", () => {
+
+  describe("Renderização do componente", () => {
+    // before em todos os testes segue o mesmo processo: adicionar dois itens, um com imagem e outro sem
+    // depois de adicionar, o usuário é deslogado
+    let idComImagem: string, idSemImagem: string
+    before(() => {
+      cy.loginComponent(auth, "test@mail", "testpassword").then(() => {
+        cy.fixture("images/default_image.png").then(async (fileContent) => {
+          idComImagem = await addInfoWithImage(fileContent)
+        }).then(async () => {
+          idSemImagem = await addInfoWithoutImage()
+        }).then(() => {
+          cy.logoutComponent(auth)
+        })
+      })
+    })
+    it("Deve renderizar o componente normalmente com item válido e com imagem ", () => {
+      cy.mount(
+        <ThemeProvider theme={theme}>
+          <InfoSection id={idComImagem} />
+        </ThemeProvider>
+      )
+      cy.get("[data-cy='info-title']").should("exist")
+      cy.get("[data-cy='info-text']").should("exist")
+      cy.get("[data-cy='info-image']").should("exist")
+    })
+    it("Deve renderizar o componente normalmente com item válido e sem imagem", () => {
+      cy.mount(
+        <ThemeProvider theme={theme}>
+          <InfoSection id={idSemImagem} />
+        </ThemeProvider>
+      )
+      cy.get("[data-cy='info-title']").should("exist")
+      cy.get("[data-cy='info-text']").should("exist")
+    })
+    it("Deve renderizar erro com id inválido", () => {
+      cy.mount(
+        <ThemeProvider theme={theme}>
+          <InfoSection id='-1' />
+        </ThemeProvider>)
+      cy.get("[data-cy='info-error-title']").should("exist")
+    })
+    describe("Visualização mobile", () => {
+      before(() => {
+        cy.viewport("samsung-s10")
+      })
+      it("Deve renderizar conteúdo em uma coluna", () => {
+        cy.mount(
+          <ThemeProvider theme={theme}>
+            <InfoSection id={idComImagem} />
+          </ThemeProvider>
+        )
+        cy.get("section").should("have.css", "flex-direction", "column-reverse")
+      })
+    })
+
+    describe("Visualização desktop", () => {
+      before(() => {
+        cy.viewport(1366, 768)
+      })
+
+      it("deve renderizar imagem ao lado do texto", () => {
+        cy.mount(
+          <ThemeProvider theme={theme}>
+            <InfoSection id={idComImagem} />
+          </ThemeProvider>
+        )
+        cy.get("[data-cy='info-title']").should("exist")
+        cy.get("section").children().then(($children) => {
+          const firstChildTop = $children.first().position().top;
+
+          // verificando se todas as divs estão na mesma linha
+          $children.each((_, child) => {
+            expect(Cypress.$(child).position().top).to.eq(firstChildTop);
+          });
+        })
+      })
+    })
+  })
+
+  describe("Interação usuário não logado", () => {
+    let idSemImagem: string
+    before(() => {
+      cy.loginComponent(auth, "test@mail", "testpassword").then(async () => {
+        idSemImagem = await addInfoWithoutImage()
+      }).then(() => {
+        cy.logoutComponent(auth)
+      })
+    })
+    it("Não deve permitir edição", () => {
+      cy.mount(
+        <ThemeProvider theme={theme}>
+          <InfoSection id={idSemImagem} />
+        </ThemeProvider>
+      )
+      cy.get("[data-cy='info-title']").should("exist")
+      cy.get("[data-cy='info-edit-button']").should("not.exist")
+    })
+  })
+
+  describe("Interação usuário logado", () => {
+    let idComImagem: string, idSemImagem: string
+    before(() => {
+      cy.loginComponent(auth, "test@mail", "testpassword").then(() => {
+        cy.fixture("images/default_image.png").then(async (fileContent) => {
+          idComImagem = await addInfoWithImage(fileContent)
+        }).then(async () => {
+          idSemImagem = await addInfoWithoutImage()
+        })
+      })
+    })
+    it("Deve permitir edição do título", () => {
+      cy.mount(
+        <ThemeProvider theme={theme}>
+          <InfoSection id={idSemImagem} />
+        </ThemeProvider>
+      )
+      cy.get("[data-cy='info-edit-button']").click().then(() => {
+        cy.get("[data-cy='info-title']").should("not.exist")
+
+        cy.get("[data-cy='info-edit-title-field']").should("exist").find('input').clear().then(() => {
+          cy.get("[data-cy='info-edit-title-field']").type("Teste de edição")
+        })
+
+        cy.get("[data-cy='info-submit-button']").click().then(() => {
+          cy.get("[data-cy='info-title']").should("exist")
+          cy.get("[data-cy='info-title']").contains("Teste de edição")
+        })
+      })
+    })
+
+    it("Deve permitir edição do texto", () => {
+      cy.mount(
+        <ThemeProvider theme={theme}>
+          <InfoSection id={idSemImagem} />
+        </ThemeProvider>
+      )
+      cy.get("[data-cy='info-edit-button']").click().then(() => {
+        cy.get("[data-cy='info-text']").should("not.exist")
+
+        cy.get("[data-cy='info-edit-text-field']").should("exist").click().find('textarea').first().clear().then(() => {
+          cy.get("[data-cy='info-edit-text-field']").type("Teste de edição")
+        })
+
+        cy.get("[data-cy='info-submit-button']").click().then(() => {
+          cy.get("[data-cy='info-text']").should("exist")
+          cy.get("[data-cy='info-text']").contains("Teste de edição")
+        })
+      })
+    })
+
+    it("Deve permitir alteração da imagem", () => {
+      cy.mount(
+        <ThemeProvider theme={theme}>
+          <InfoSection id={idComImagem} />
+        </ThemeProvider>
+      )
+      cy.fixture("images/default_image_copy.png").as("defaultImageCopy");
+      cy.get("[data-cy='info-edit-button']").click().then(() => {
+        cy.get("[data-cy='info-image']").should("exist").then(($image) => {
+          const src = $image.attr("src")
+          cy.get("[data-cy='info-image-button']").selectFile("@defaultImageCopy").then(() => {
+            cy.get("[data-cy='info-submit-button']").click().then(() => {
+              cy.get("[data-cy='info-title']").should("exist").then(() => {
+                cy.get("[data-cy='info-image']").should("exist").should("have.attr", "src").should("not.eq", src)
+              })
+            })
+          })
+        })
+      })
+    })
+    it("Deve permitir alteração do texto alternativo", () => {
+      cy.mount(
+        <ThemeProvider theme={theme}>
+          <InfoSection id={idComImagem} />
+        </ThemeProvider>
+      )
+      cy.get("[data-cy='info-edit-button']").click().then(() => {
+        cy.get("[data-cy='info-image']").should("exist")
+        cy.get("[data-cy='info-image-alt-field']").should("exist").click().find('input').clear().type("Texto alternativo")
+        cy.get("[data-cy='info-submit-button']").click().then(() => {
+          cy.get("[data-cy='info-title']").should("exist")
+          cy.get("[data-cy='info-image']").should("exist").should("have.attr", "alt", "Texto alternativo")
+        })
+      })
+    })
+    it("Deve permitir remoção da imagem", () => {
+      cy.mount(
+        <ThemeProvider theme={theme}>
+          <InfoSection id={idComImagem} />
+        </ThemeProvider>
+      )
+      cy.get("[data-cy='info-edit-button']").click().then(() => {
+        cy.get("[data-cy='info-image']").should("exist")
+        cy.get("[data-cy='info-image-remove-button']").click().then(() => {
+          cy.get("[data-cy='info-image']").should("not.exist")
+        })
+      })
+    })
+
+    it("Deve manter o mesmo conteúdo ao cancelar a edição", () => {
+      cy.mount(
+        <ThemeProvider theme={theme}>
+          <InfoSection id={idSemImagem} />
+        </ThemeProvider>
+      )
+      cy.get("[data-cy='info-text']").should("exist").then(($infoTextSpan) => {
+        const previousText = $infoTextSpan.text()
+        cy.get("[data-cy='info-edit-button']").click().then(() => {
+          cy.get("[data-cy='info-text']").should("not.exist")
+          cy.get("[data-cy='info-edit-text-field']").should("exist").click().find('textarea').first().clear().type(previousText + ' editado')
+
+          cy.get("[data-cy='info-cancel-button']").click().then(() => {
+            cy.get("[data-cy='info-text']").should("exist")
+            cy.get("[data-cy='info-text']").invoke("text").should("equal", previousText)
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/components/InfoSection/useInfoMuseu.ts
+++ b/src/components/InfoSection/useInfoMuseu.ts
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import {
+  atualizarInfoMuseu,
+  subscribeInfoMuseu,
+} from "../../Utils/infoMuseuFirebase";
+import { InfoMuseu } from "../../interfaces/InfoMuseu";
+
+type Status = "loading" | "success" | "error";
+
+type useInfoSectionReturnType = {
+  status: Status;
+  infoMuseu: InfoMuseu | null;
+  atualizarInfoMuseu: (info: InfoMuseu) => Promise<void>;
+};
+
+/**
+ * hook que retorna uma informação do museu junto do callback para atualizar ela
+ * @param id
+ * @returns infoMuseu com o id respectivo e a função atualizar fixada para o id passado
+ */
+const useInfoMuseu = (id: string): useInfoSectionReturnType => {
+  const [data, setData] = useState<InfoMuseu | null>(null);
+  const [status, setStatus] = useState<Status>("loading");
+
+  const unsubscribe = subscribeInfoMuseu(id, data, setData, setStatus);
+
+  if (status === "error" || status === "success") {
+    unsubscribe();
+  }
+  //função de update fixada no id passado
+  const update = atualizarInfoMuseu.bind(null, id);
+
+  return { status: status, infoMuseu: data, atualizarInfoMuseu: update };
+};
+
+export default useInfoMuseu;

--- a/src/hooks/useInfoMuseuForm.ts
+++ b/src/hooks/useInfoMuseuForm.ts
@@ -1,29 +1,63 @@
-import { FormState, useForm, Control, UseFormRegister } from 'react-hook-form';
-import { InfoMuseu } from '../interfaces/InfoMuseu';
+import { useEffect } from "react";
+import {
+  Control,
+  FormState,
+  UseFormHandleSubmit,
+  UseFormRegister,
+  UseFormReset,
+  UseFormResetField,
+  UseFormSetValue,
+  UseFormWatch,
+  useForm,
+} from "react-hook-form";
+import { InfoMuseu } from "../interfaces/InfoMuseu";
 
-const useInfoMuseuForm = (defaultValues?: InfoMuseu): {
+type Status = "loading" | "success" | "error";
+
+interface InfoMuseuFormReturnType {
   register: UseFormRegister<InfoMuseu>;
   control: Control<InfoMuseu>;
-  handleSubmit: <T>(callback: (data: InfoMuseu) => Promise<void>) => (event: React.SyntheticEvent) => void;
+  handleSubmit: UseFormHandleSubmit<InfoMuseu, undefined>;
   formState: FormState<InfoMuseu>;
-} => {
-  // Verifique se defaultValues é undefined e atribua valores padrão apropriados
-  if (defaultValues === undefined) {
-    defaultValues = {
-      nome: '',
-      texto: '',
-      //Não é possível definir um objeto vazio como valor padrão para imagem, pois ele contém propriedades obrigatórias
-      imagem: {
-        src: '',
-        title: '',
-        alt: '',
-      },
-    };
-  }
-
-  const { register, control, handleSubmit, formState } = useForm<InfoMuseu>({ defaultValues });
-
-  return { register, control, handleSubmit, formState };
+  watch: UseFormWatch<InfoMuseu>;
+  setValue: UseFormSetValue<InfoMuseu>;
+  reset: UseFormReset<InfoMuseu>;
+  resetField: UseFormResetField<InfoMuseu>;
 }
+
+const useInfoMuseuForm = (
+  infoMuseu?: InfoMuseu,
+  loaded?: Status
+): InfoMuseuFormReturnType => {
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState,
+    watch,
+    setValue,
+    reset,
+    resetField,
+  } = useForm<InfoMuseu>({
+    defaultValues: { nome: "", texto: "" },
+  });
+  //necessário utilizar useEffect por que o valor de
+  //defaultValues fica como cache após a primeira renderização
+  //adicionar infoMuseu como dependência do useEffect causa uma atualização infinita
+  useEffect(() => {
+    reset(infoMuseu ? infoMuseu : { nome: "", texto: "" });
+  }, [loaded]);
+
+  return {
+    register,
+    control,
+    handleSubmit,
+    formState,
+    watch,
+    setValue,
+    reset,
+    resetField,
+  };
+};
 
 export default useInfoMuseuForm;

--- a/src/interfaces/InfoMuseu.ts
+++ b/src/interfaces/InfoMuseu.ts
@@ -1,5 +1,5 @@
 export interface InfoMuseu {
   nome: string;
   texto: string;
-  imagem: Imagem;
+  imagem?: Imagem;
 }


### PR DESCRIPTION
# Feature InfoSection

## Resolve
#74 

## Descrição

Adicionando componente editável para uma informação do museu, contendo título, texto e uma imagem opcional

## Adições

- Componente infoSection, com visualização de carregamento e de erro
- Testes do componente
- Custom hook para buscar informações do museu
- Método `subscribeInfoMuseu` 
- Método `getInfoUsingImageCount` que retorna o número de documentos utilizando uma imagem

## Alterações

- Buscando imagem de uma informação em um método separado de getInfoMuseu
- Deletando uma imagem caso não seja utilizada em outros documentos em `atualizarInfoMuseu` e `deletarInfoMuseu`
- Definindo valores default no hook do formulário com a função reset
- Tipos de retorno do hook do formulário iguais ao do hook useForm
- Mudando ordem dos parâmetros no construtor de FirebaseError

## Verificando

### Desenvolvedor

- [ ] Teste de componente/e2e implementados

### Revisor

- [x] Funcionalidade verificada localmente
- [x] Novos testes passam localmente e nos workflows
