### PR TITLE
Feat/listar acervo fixed

### DIFF
--- a/cypress/e2e/Acervo.test.ts
+++ b/cypress/e2e/Acervo.test.ts
@@ -1,88 +1,39 @@
-import { ItemAcervo } from '../../src/interfaces/ItemAcervo';
-import * as itemAcervoFirebase from '../../src/Utils/itemAcervoFirebase';
-import { auth } from '../../firebase/firebase';
-
-const mockItems: ItemAcervo[] = [
-  { id: '1', nome: 'Item A', colecao: 'Coleção 1', privado: false, dataDoacao: new Date('2023-01-01'), descricao: 'Descrição do Item A', curiosidades: 'Curiosidades sobre o Item A', doacao: true, doacaoAnonima: false, imagens: [], nomeDoador: 'Doador A', telefoneDoador: '123456789' },
-  { id: '2', nome: 'Item B', colecao: 'Coleção 2', privado: false, dataDoacao: new Date('2023-02-01'), descricao: 'Descrição do Item B', curiosidades: 'Curiosidades sobre o Item B', doacao: true, doacaoAnonima: true, imagens: [], nomeDoador: '', telefoneDoador: '' },
-  { id: '3', nome: 'Item C', colecao: 'Coleção 1', privado: true, dataDoacao: new Date('2023-03-01'), descricao: 'Descrição do Item C', curiosidades: 'Curiosidades sobre o Item C', doacao: false, doacaoAnonima: false, imagens: [], nomeDoador: 'Doador C', telefoneDoador: '987654321' },
-  { id: '4', nome: 'Item D', colecao: 'Coleção 3', privado: false, dataDoacao: new Date('2023-04-01'), descricao: 'Descrição do Item D', curiosidades: 'Curiosidades sobre o Item D', doacao: true, doacaoAnonima: false, imagens: [], nomeDoador: 'Doador D', telefoneDoador: '456789123' },
-  { id: '5', nome: 'Item E', colecao: 'Coleção 2', privado: false, dataDoacao: new Date('2023-05-01'), descricao: 'Descrição do Item E', curiosidades: 'Curiosidades sobre o Item E', doacao: true, doacaoAnonima: true, imagens: [], nomeDoador: '', telefoneDoador: '' },
-  { id: '6', nome: 'Item F', colecao: 'Coleção 3', privado: true, dataDoacao: new Date('2023-06-01'), descricao: 'Descrição do Item F', curiosidades: 'Curiosidades sobre o Item F', doacao: false, doacaoAnonima: false, imagens: [], nomeDoador: 'Doador F', telefoneDoador: '321654987' },
-  { id: '7', nome: 'Item G', colecao: 'Coleção 1', privado: false, dataDoacao: new Date('2023-07-01'), descricao: 'Descrição do Item G', curiosidades: 'Curiosidades sobre o Item G', doacao: true, doacaoAnonima: false, imagens: [], nomeDoador: 'Doador G', telefoneDoador: '789456123' },
-];
-
-describe('Página Acervo', () => {
+describe('Acervo', () => {
   beforeEach(() => {
-    cy.stub(itemAcervoFirebase, 'getItensAcervo').resolves(mockItems);
-    cy.visit('/acervo');
+    cy.visit("/acervo-mock");
   });
 
   it('deve renderizar o loading e os itens em caso de sucesso', () => {
-    cy.get('[data-cy="loading"]').should('be.visible');
-    cy.get('[data-cy="item-card-container"]').should('have.length', 6);
+    cy.get("[data-cy='loading']").should("exist");
+    cy.get("[data-cy='loading']").should("not.exist");
+    cy.get("[data-cy='card-item-container']").should("have.length", 6);
   });
 
-  it('deve carregar inicialmente os últimos 6 itens cadastrados em ordem alfabética', () => {
-    cy.get('[data-cy="item-card-container"]').should('have.length', 6);
-    cy.get('[data-cy="item-card-container"]').first().should('contain', 'Item G');
-    cy.get('[data-cy="item-card-container"]').last().should('contain', 'Item B');
-  });
-
-  it('deve adicionar itens privados quando o usuário está logado', () => {
-    cy.stub(auth, 'currentUser').value({ uid: 'mockUserId' });
-    cy.reload();
-    cy.get('[data-cy="item-card-container"]').should('have.length', 7);
-    cy.get('[data-cy="item-card-container"]').should('contain', 'Item C');
-    cy.get('[data-cy="item-card-container"]').should('contain', 'Item F');
-  });
-
-  it('não deve mostrar o mesmo item duas vezes em nenhuma página', () => {
-    cy.get('[data-cy="item-card-container"]').then($cards => {
-      const itemNames = $cards.map((_, el) => Cypress.$(el).text()).get();
-      const uniqueItemNames = new Set(itemNames);
-      expect(itemNames.length).to.equal(uniqueItemNames.size);
+  it('deve carregar os últimos 6 itens em ordem decrescente', function() {
+    cy.get("[data-cy='card-item-container']").then(($items) => {
+      const ids = $items.map((_, el) => Number(el.getAttribute("data-id"))).get();
+      const idsOrdenados = [...ids].sort((a, b) => b - a);
+      expect(ids).to.deep.equal(idsOrdenados);
     });
   });
 
-  it('deve filtrar itens por nome', () => {
-    cy.get('[data-cy="nome-filter"]').type('Item A');
-    cy.get('[data-cy="item-card-container"]').should('have.length', 1);
-    cy.get('[data-cy="item-card-container"]').should('contain', 'Item A');
+  it('deve mostrar apenas itens públicos quando não logado', () => {
+    cy.logout();
+    cy.get("[data-cy='item-publico']").should('be.visible');
+    cy.get("[data-cy='item-privado']").should('not.exist');
   });
 
-  it('deve filtrar itens por coleção', () => {
-    cy.get('[data-cy="colecao-filter"]').click();
-    cy.contains('Coleção 1').click();
-    cy.get('[data-cy="item-card-container"]').should('have.length', 2);
-    cy.get('[data-cy="item-card-container"]').should('contain', 'Item A');
-    cy.get('[data-cy="item-card-container"]').should('contain', 'Item G');
+  it('deve mostrar itens privados quando logado', () => {
+    cy.login();
+    cy.visit("/acervo-mock");
+    cy.get("[data-cy='card-item-container']").find("[data-cy='item-privado']").should("exist");
   });
 
-  it('deve ordenar itens alfabeticamente', () => {
-    cy.get('[data-cy="alfabetic-order"]').click();
-    cy.get('[data-cy="item-card-container"]').first().should('contain', 'Item A');
-    cy.get('[data-cy="alfabetic-order"]').click();
-    cy.get('[data-cy="item-card-container"]').first().should('contain', 'Item G');
-  });
-
-  it('deve ordenar itens por data', () => {
-    cy.get('[data-cy="date-order"]').click();
-    cy.get('[data-cy="item-card-container"]').first().should('contain', 'Item A');
-    cy.get('[data-cy="date-order"]').click();
-    cy.get('[data-cy="item-card-container"]').first().should('contain', 'Item G');
-  });
-
-  it('deve limpar os filtros ao clicar no botão de limpar', () => {
-    cy.get('[data-cy="nome-filter"]').type('Item A');
-    cy.get('[data-cy="clear-filters"]').click();
-    cy.get('[data-cy="nome-filter"]').should('have.value', '');
-    cy.get('[data-cy="item-card-container"]').should('have.length', 6);
-  });
-
-  it('deve paginar corretamente os resultados', () => {
-    cy.get('[data-cy="pagination"]').contains('2').click();
-    cy.get('[data-cy="item-card-container"]').should('have.length', 1);
-    cy.get('[data-cy="item-card-container"]').should('contain', 'Item A');
+  it('não deve repetir itens na mesma página', () => {
+    cy.get("[data-cy='card-item-container']").then(($items) => {
+      const ids = $items.map((index, el) => el.getAttribute("data-id")).get();
+      const idsUnicos = new Set(ids);
+      expect(ids.length).to.equal(idsUnicos.size);
+    });
   });
 });

--- a/cypress/e2e/Acervo.test.ts
+++ b/cypress/e2e/Acervo.test.ts
@@ -1,0 +1,88 @@
+import { ItemAcervo } from '../../src/interfaces/ItemAcervo';
+import * as itemAcervoFirebase from '../../src/Utils/itemAcervoFirebase';
+import { auth } from '../../firebase/firebase';
+
+const mockItems: ItemAcervo[] = [
+  { id: '1', nome: 'Item A', colecao: 'Coleção 1', privado: false, dataDoacao: new Date('2023-01-01'), descricao: 'Descrição do Item A', curiosidades: 'Curiosidades sobre o Item A', doacao: true, doacaoAnonima: false, imagens: [], nomeDoador: 'Doador A', telefoneDoador: '123456789' },
+  { id: '2', nome: 'Item B', colecao: 'Coleção 2', privado: false, dataDoacao: new Date('2023-02-01'), descricao: 'Descrição do Item B', curiosidades: 'Curiosidades sobre o Item B', doacao: true, doacaoAnonima: true, imagens: [], nomeDoador: '', telefoneDoador: '' },
+  { id: '3', nome: 'Item C', colecao: 'Coleção 1', privado: true, dataDoacao: new Date('2023-03-01'), descricao: 'Descrição do Item C', curiosidades: 'Curiosidades sobre o Item C', doacao: false, doacaoAnonima: false, imagens: [], nomeDoador: 'Doador C', telefoneDoador: '987654321' },
+  { id: '4', nome: 'Item D', colecao: 'Coleção 3', privado: false, dataDoacao: new Date('2023-04-01'), descricao: 'Descrição do Item D', curiosidades: 'Curiosidades sobre o Item D', doacao: true, doacaoAnonima: false, imagens: [], nomeDoador: 'Doador D', telefoneDoador: '456789123' },
+  { id: '5', nome: 'Item E', colecao: 'Coleção 2', privado: false, dataDoacao: new Date('2023-05-01'), descricao: 'Descrição do Item E', curiosidades: 'Curiosidades sobre o Item E', doacao: true, doacaoAnonima: true, imagens: [], nomeDoador: '', telefoneDoador: '' },
+  { id: '6', nome: 'Item F', colecao: 'Coleção 3', privado: true, dataDoacao: new Date('2023-06-01'), descricao: 'Descrição do Item F', curiosidades: 'Curiosidades sobre o Item F', doacao: false, doacaoAnonima: false, imagens: [], nomeDoador: 'Doador F', telefoneDoador: '321654987' },
+  { id: '7', nome: 'Item G', colecao: 'Coleção 1', privado: false, dataDoacao: new Date('2023-07-01'), descricao: 'Descrição do Item G', curiosidades: 'Curiosidades sobre o Item G', doacao: true, doacaoAnonima: false, imagens: [], nomeDoador: 'Doador G', telefoneDoador: '789456123' },
+];
+
+describe('Página Acervo', () => {
+  beforeEach(() => {
+    cy.stub(itemAcervoFirebase, 'getItensAcervo').resolves(mockItems);
+    cy.visit('/acervo');
+  });
+
+  it('deve renderizar o loading e os itens em caso de sucesso', () => {
+    cy.get('[data-cy="loading"]').should('be.visible');
+    cy.get('[data-cy="item-card-container"]').should('have.length', 6);
+  });
+
+  it('deve carregar inicialmente os últimos 6 itens cadastrados em ordem alfabética', () => {
+    cy.get('[data-cy="item-card-container"]').should('have.length', 6);
+    cy.get('[data-cy="item-card-container"]').first().should('contain', 'Item G');
+    cy.get('[data-cy="item-card-container"]').last().should('contain', 'Item B');
+  });
+
+  it('deve adicionar itens privados quando o usuário está logado', () => {
+    cy.stub(auth, 'currentUser').value({ uid: 'mockUserId' });
+    cy.reload();
+    cy.get('[data-cy="item-card-container"]').should('have.length', 7);
+    cy.get('[data-cy="item-card-container"]').should('contain', 'Item C');
+    cy.get('[data-cy="item-card-container"]').should('contain', 'Item F');
+  });
+
+  it('não deve mostrar o mesmo item duas vezes em nenhuma página', () => {
+    cy.get('[data-cy="item-card-container"]').then($cards => {
+      const itemNames = $cards.map((_, el) => Cypress.$(el).text()).get();
+      const uniqueItemNames = new Set(itemNames);
+      expect(itemNames.length).to.equal(uniqueItemNames.size);
+    });
+  });
+
+  it('deve filtrar itens por nome', () => {
+    cy.get('[data-cy="nome-filter"]').type('Item A');
+    cy.get('[data-cy="item-card-container"]').should('have.length', 1);
+    cy.get('[data-cy="item-card-container"]').should('contain', 'Item A');
+  });
+
+  it('deve filtrar itens por coleção', () => {
+    cy.get('[data-cy="colecao-filter"]').click();
+    cy.contains('Coleção 1').click();
+    cy.get('[data-cy="item-card-container"]').should('have.length', 2);
+    cy.get('[data-cy="item-card-container"]').should('contain', 'Item A');
+    cy.get('[data-cy="item-card-container"]').should('contain', 'Item G');
+  });
+
+  it('deve ordenar itens alfabeticamente', () => {
+    cy.get('[data-cy="alfabetic-order"]').click();
+    cy.get('[data-cy="item-card-container"]').first().should('contain', 'Item A');
+    cy.get('[data-cy="alfabetic-order"]').click();
+    cy.get('[data-cy="item-card-container"]').first().should('contain', 'Item G');
+  });
+
+  it('deve ordenar itens por data', () => {
+    cy.get('[data-cy="date-order"]').click();
+    cy.get('[data-cy="item-card-container"]').first().should('contain', 'Item A');
+    cy.get('[data-cy="date-order"]').click();
+    cy.get('[data-cy="item-card-container"]').first().should('contain', 'Item G');
+  });
+
+  it('deve limpar os filtros ao clicar no botão de limpar', () => {
+    cy.get('[data-cy="nome-filter"]').type('Item A');
+    cy.get('[data-cy="clear-filters"]').click();
+    cy.get('[data-cy="nome-filter"]').should('have.value', '');
+    cy.get('[data-cy="item-card-container"]').should('have.length', 6);
+  });
+
+  it('deve paginar corretamente os resultados', () => {
+    cy.get('[data-cy="pagination"]').contains('2').click();
+    cy.get('[data-cy="item-card-container"]').should('have.length', 1);
+    cy.get('[data-cy="item-card-container"]').should('contain', 'Item A');
+  });
+});

--- a/src/components/CardItemAcervo/CardItemAcervo.tsx
+++ b/src/components/CardItemAcervo/CardItemAcervo.tsx
@@ -107,10 +107,10 @@ const CardItemAcervo: React.FC<CardItemAcervoProps> = ({ item }) => {
         />
       )}
       <CardContent>
-        <Typography variant="body1" sx={{ fontSize: '20px' }}>
+        <Typography variant="body1" sx={{ fontSize: '20px' }} data-cy="card-item-nome">
           {nome ? nome : 'Nome do item'}
         </Typography>
-        <Typography variant="body2" sx={{ fontSize: '15px' }}>
+        <Typography variant="body2" sx={{ fontSize: '15px' }} data-cy={privado ? 'item-privado' : 'item-publico'}>
           {privado ? 'Fora de exposição' : 'Em exposição'}
         </Typography>
         <Typography sx={{ marginTop: '15px', marginBottom: '15px' }} data-cy='card-item-description'>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -24,7 +24,7 @@ import { loginMethods } from '../../Utils/loginGoogle'
 //Need to define links to other pages
 const pages = [
   { label: "Exposições", sectionItem: "Criar exposição", seacrhLink: "/", otherLink: "exposicoes/criar-exposicao" },
-  { label: "Acervo", sectionItem: "Adicionar item", seacrhLink: "/", otherLink: "acervo/criar-item", otherSection: "Criar coleção", anotherLink: "colecoes/criar-colecao" },
+  { label: "Acervo", sectionItem: "Adicionar item", seacrhLink: "acervo", otherLink: "acervo/criar-item", otherSection: "Criar coleção", anotherLink: "colecoes/criar-colecao" },
   { label: "Editais e normas", sectionItem: "Cadastrar normativa", seacrhLink: "/", otherLink: "/" },
 ]
 

--- a/src/pages/Acervo.tsx
+++ b/src/pages/Acervo.tsx
@@ -1,0 +1,258 @@
+// src/pages/Acervo.tsx
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { 
+  Box, Typography, TextField, IconButton, Grid, Pagination,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from '@mui/material';
+import { 
+  Clear as ClearIcon,
+  ArrowUpward as ArrowUpIcon,
+  ArrowDownward as ArrowDownIcon,
+  SortByAlpha
+} from '@mui/icons-material';
+import { styled } from '@mui/material/styles';
+import CardItemAcervo from '../components/CardItemAcervo/CardItemAcervo';
+import { ItemAcervo } from '../interfaces/ItemAcervo';
+import { auth } from '../../firebase/firebase';
+import { CalendarIcon } from '@mui/x-date-pickers';
+import { getItensAcervo } from '../Utils/itemAcervoFirebase';
+
+const Content = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(3),
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(3)
+}));
+
+const Heading = styled(Box)(() => ({
+  textAlign: 'center'
+}));
+
+const List = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(2)
+}));
+
+const Filter = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(2)
+}));
+
+const Description = styled(Box)(() => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center'
+}));
+
+const Acervo: React.FC = () => {
+  const [itens, setItens] = useState<ItemAcervo[]>([]);
+  const [filteredItens, setFilteredItens] = useState<ItemAcervo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  
+  const [nomeFilter, setNomeFilter] = useState('');
+  const [colecaoFilter, setColecaoFilter] = useState('');
+  const [colecoes, setColecoes] = useState<string[]>([]);
+  
+  const [alfabeticOrder, setAlfabeticOrder] = useState<'asc' | 'desc' | 'none'>('none');
+  const [dateOrder, setDateOrder] = useState<'asc' | 'desc' | 'none'>('desc');
+  
+  const [page, setPage] = useState(1);
+  const itemsPerPage = 6;
+
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const currentUser = auth.currentUser;
+    setIsLoggedIn(!!currentUser);
+  }, []);
+
+  const fetchItens = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await getItensAcervo(isLoggedIn ? true : false);
+      setItens(data);
+      setFilteredItens(data);
+      // Extrair coleções únicas
+      const uniqueColecoes = Array.from(new Set(data.map(item => item.colecao)));
+      setColecoes(uniqueColecoes);
+    } catch (err) {
+      setError('Erro ao buscar itens do acervo');
+    } finally {
+      setLoading(false);
+    }
+  }, [isLoggedIn]);
+
+  useEffect(() => {
+    fetchItens();
+  }, [fetchItens]);
+
+  useEffect(() => {
+    let filtered = itens.filter(item => isLoggedIn || !item.privado);
+    
+    if (nomeFilter) {
+      filtered = filtered.filter(item => 
+        item.nome.toLowerCase().includes(nomeFilter.toLowerCase())
+      );
+    }
+    
+    if (colecaoFilter) {
+      filtered = filtered.filter(item => item.colecao === colecaoFilter);
+    }
+  
+    // Aplicar apenas uma ordenação de cada vez
+    if (alfabeticOrder !== 'none') {
+      filtered.sort((a, b) => {
+        return alfabeticOrder === 'asc' 
+          ? a.nome.localeCompare(b.nome)
+          : b.nome.localeCompare(a.nome);
+      });
+    } else if (dateOrder !== 'none') {
+      filtered.sort((a, b) => {
+        const dateA = a.dataDoacao instanceof Date ? a.dataDoacao.getTime() : 0;
+        const dateB = b.dataDoacao instanceof Date ? b.dataDoacao.getTime() : 0;
+        return dateOrder === 'asc' ? dateA - dateB : dateB - dateA;
+      });
+    }
+  
+    setFilteredItens(filtered);
+    setPage(1);
+  }, [itens, nomeFilter, colecaoFilter, alfabeticOrder, dateOrder, isLoggedIn]);
+
+  const clearFilters = useCallback(() => {
+    setNomeFilter('');
+    setColecaoFilter('');
+    setAlfabeticOrder('none');
+    setDateOrder('desc');
+  }, []);
+
+  const toggleAlfabeticOrder = useCallback(() => {
+    setAlfabeticOrder(prev => {
+      if (prev === 'asc') return 'desc';
+      if (prev === 'desc') return 'none';
+      return 'asc';
+    });
+    setDateOrder('none');
+    setPage(1);
+  }, []);
+  
+  const toggleDateOrder = useCallback(() => {
+    setDateOrder(prev => {
+      if (prev === 'asc') return 'desc';
+      if (prev === 'desc') return 'none';
+      return 'asc';
+    });
+    setAlfabeticOrder('none');
+    setPage(1);
+  }, []);
+
+  const handlePageChange = useCallback((event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+    void(event)
+  }, []);
+
+  if (loading) {
+    return <CircularProgress data-cy="loading" />;
+  }
+
+  if (error) {
+    return <Typography color="error" data-cy="error-message">{error}</Typography>;
+  }
+
+  const paginatedItens = filteredItens.slice(
+    (page - 1) * itemsPerPage, 
+    page * itemsPerPage
+  );
+
+  return (
+    <Content data-cy="acervo-content">
+      <Heading>
+        <Typography variant="h4" sx={{paddingTop: '32px'}} data-cy="acervo-title">Acervo</Typography>
+        <Typography variant="subtitle1" data-cy="acervo-subtitle">Explore os itens do nosso acervo</Typography>
+      </Heading>
+      
+      <List sx={{
+            display: 'flex',
+            alignItems: 'center',
+            }}
+        >
+        <Filter>
+          <TextField 
+            label="Nome do item"
+            value={nomeFilter}
+            onChange={(e) => setNomeFilter(e.target.value)}
+            inputProps={{ 'data-cy': 'nome-filter' }}
+          />
+          <FormControl sx={{minWidth: '150px'}}>
+            <InputLabel>Coleção</InputLabel>
+            <Select
+              value={colecaoFilter}
+              onChange={(e) => setColecaoFilter(e.target.value as string)}
+              label="Coleção"
+              inputProps={{ 'data-cy': 'colecao-filter' }}
+            >
+              <MenuItem value="">Todas</MenuItem>
+              {colecoes.map((colecao) => (
+                <MenuItem key={colecao} value={colecao}>{colecao}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Filter>
+        
+        <Description>
+          <Box>
+            <IconButton onClick={toggleAlfabeticOrder} data-cy="alfabetic-order">
+              <SortByAlpha />
+              {alfabeticOrder === 'asc' ? <ArrowUpIcon /> : alfabeticOrder === 'desc' ? <ArrowDownIcon /> : null}
+            </IconButton>
+            <IconButton onClick={toggleDateOrder} data-cy="date-order">
+              <CalendarIcon />
+              {dateOrder === 'asc' ? <ArrowUpIcon /> : dateOrder === 'desc' ? <ArrowDownIcon /> : null}
+            </IconButton>
+            <IconButton onClick={clearFilters} data-cy="clear-filters">
+              <ClearIcon />
+            </IconButton>
+          </Box>
+          <Typography data-cy="items-count">
+            {filteredItens.length} itens encontrados
+          </Typography>
+        </Description>
+
+        <Pagination 
+              count={Math.ceil(filteredItens.length / itemsPerPage)}
+              page={page}
+              onChange={handlePageChange}
+              data-cy="pagination"
+        />
+
+        {filteredItens.length === 0 ? (
+          <Typography data-cy="no-items-message">Nenhum item encontrado com os filtros atuais</Typography>
+        ) : (
+          <>
+            <Grid container spacing={2} data-cy="items-grid">
+              {paginatedItens.map(item => (
+                <Grid item xs={12} sm={6} md={4} key={item.id}>
+                  <CardItemAcervo item={item} data-cy="item-card" />
+                </Grid>
+              ))}
+            </Grid>
+            <Pagination 
+              count={Math.ceil(filteredItens.length / itemsPerPage)}
+              page={page}
+              onChange={handlePageChange}
+              data-cy="pagination"
+            />
+          </>
+        )}
+      </List>
+    </Content>
+  );
+};
+
+export default Acervo;

--- a/src/pages/AcervoMock.tsx
+++ b/src/pages/AcervoMock.tsx
@@ -15,7 +15,22 @@ import { onAuthStateChanged } from 'firebase/auth';
 import CardItemAcervo from '../components/CardItemAcervo/CardItemAcervo';
 import { ItemAcervo } from '../interfaces/ItemAcervo';
 import { auth } from '../../firebase/firebase';
-import { getItensAcervo } from '../Utils/itemAcervoFirebase';
+
+const getItensAcervo = async (isLoggedIn: boolean): Promise<ItemAcervo[]> => {
+  const mockItems = [
+    { id: '1', nome: 'Item A', colecao: 'Coleção 1', privado: false, dataDoacao: new Date('2024-09-01'), descricao: '', curiosidades: '', doacao: false, doacaoAnonima: false, nomeDoador: '', telefoneDoador: '', imagens: [] },
+    { id: '2', nome: 'Item B', colecao: 'Coleção 2', privado: false, dataDoacao: new Date('2024-09-02'), descricao: '', curiosidades: '', doacao: false, doacaoAnonima: false, nomeDoador: '', telefoneDoador: '', imagens: [] },
+    { id: '3', nome: 'Item C', colecao: 'Coleção 1', privado: true, dataDoacao: new Date('2024-09-03'), descricao: '', curiosidades: '', doacao: false, doacaoAnonima: false, nomeDoador: '', telefoneDoador: '', imagens: [] },
+    { id: '4', nome: 'Item D', colecao: 'Coleção 3', privado: false, dataDoacao: new Date('2024-09-04'), descricao: '', curiosidades: '', doacao: false, doacaoAnonima: false, nomeDoador: '', telefoneDoador: '', imagens: [] },
+    { id: '5', nome: 'Item E', colecao: 'Coleção 2', privado: false, dataDoacao: new Date('2024-09-05'), descricao: '', curiosidades: '', doacao: false, doacaoAnonima: false, nomeDoador: '', telefoneDoador: '', imagens: [] },
+    { id: '6', nome: 'Item F', colecao: 'Coleção 3', privado: true, dataDoacao: new Date('2024-09-06'), descricao: '', curiosidades: '', doacao: false, doacaoAnonima: false, nomeDoador: '', telefoneDoador: '', imagens: [] },
+    { id: '7', nome: 'Item G', colecao: 'Coleção 1', privado: false, dataDoacao: new Date('2024-09-07'), descricao: '', curiosidades: '', doacao: false, doacaoAnonima: false, nomeDoador: '', telefoneDoador: '', imagens: [] },
+    { id: '8', nome: 'Item H', colecao: 'Coleção 2', privado: false, dataDoacao: new Date('2024-09-08'), descricao: '', curiosidades: '', doacao: false, doacaoAnonima: false, nomeDoador: '', telefoneDoador: '', imagens: [] },
+    { id: '9', nome: 'Item I', colecao: 'Coleção 3', privado: false, dataDoacao: new Date('2024-09-09'), descricao: '', curiosidades: '', doacao: false, doacaoAnonima: false, nomeDoador: '', telefoneDoador: '', imagens: [] },
+    { id: '10', nome: 'Item J', colecao: 'Coleção 1', privado: true, dataDoacao: new Date('2024-09-10'), descricao: '', curiosidades: '', doacao: false, doacaoAnonima: false, nomeDoador: '', telefoneDoador: '', imagens: [] }
+  ];
+  return isLoggedIn ? mockItems : mockItems.filter(item => !item.privado);
+}
 
 const Content = styled(Box)(({ theme }) => ({
   padding: theme.spacing(3),
@@ -45,7 +60,7 @@ const Description = styled(Box)(() => ({
   alignItems: 'center'
 }));
 
-const Acervo: React.FC = () => {
+const AcervoMock: React.FC = () => {
   const [itens, setItens] = useState<ItemAcervo[]>([]);
   const [filteredItens, setFilteredItens] = useState<ItemAcervo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -256,4 +271,4 @@ const Acervo: React.FC = () => {
   );
 };
 
-export default Acervo;
+export default AcervoMock;

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -6,6 +6,7 @@ import Erro from "../pages/Erro";
 import { exposicaoLoader, homeRedirectLoader, loginRedirectLoader, privateLoader } from "./loaders";
 import CriarExposicao from "../pages/CriarExposicao";
 import CriarColecao from "../pages/CriarColecao";
+import AcervoMock from "../pages/AcervoMock";
 
 const Home = React.lazy(() => import("../pages/Home"));
 const CriarItemAcervo = React.lazy(() => import("../pages/CriarItemAcervo"));
@@ -70,6 +71,13 @@ const router = createBrowserRouter([
           </Suspense>,
       },
       {
+        path: "/acervo-mock",
+        element:
+          <Suspense fallback={centeredLoading}>
+            <AcervoMock />
+          </Suspense>,
+      },
+      {
         element: <ProtectedRoutes />,
         loader: privateLoader,
         children: [
@@ -82,7 +90,7 @@ const router = createBrowserRouter([
             path: "/colecoes/criar-colecao",
             element:
               <CriarColecao/>
-          }
+          },
         ]
       },
       {

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -12,6 +12,7 @@ const CriarItemAcervo = React.lazy(() => import("../pages/CriarItemAcervo"));
 const ItemAcervo = React.lazy(() => import("../pages/ItemAcervo"));
 const PageExposicao = React.lazy(() => import("../pages/exposicoes/VisualizarExposicao"));
 const Login = React.lazy(() => import("../pages/Login"));
+const Acervo = React.lazy(() => import("../pages/Acervo"));
 
 const centeredLoading = (
   <div style={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100vh" }}>
@@ -59,6 +60,13 @@ const router = createBrowserRouter([
         element:
           <Suspense fallback={centeredLoading}>
             <Login />
+          </Suspense>,
+      },
+      {
+        path: "/acervo",
+        element:
+          <Suspense fallback={centeredLoading}>
+            <Acervo />
           </Suspense>,
       },
       {


### PR DESCRIPTION
# Feature ListarAcervo

## Resolve

#36 

# Descrição

Cria a página de listagem do acervo, exibindo os itens públicos e privados, a depender da autenticação.

## Adições

Dois novos data-cy ao CardItemAcervo (item-privado e item-publico) para facilitar os testes da página de Acervo.
Página mockada idêntica a do Acervo (a única diferença é o getItensAcervo, que retorna uma lista pronta pra não acessar o firebase). Necessário por limitações do cypress.

## Alterações

A página de acervo agora deve carregar os últimos 6 itens em ordem decrescente por ordem cronológica, e não mais em ordem alfabética, por padrão.

## Remoções

<!--Funcionalidades que foram removidas, como um componente depreciado, por exemplo-->

## Verificando

### Desenvolvedor

- [x] deve renderizar o loading e os itens em caso de sucesso
- [x] deve carregar os últimos 6 itens em ordem decrescente
- [x] deve mostrar apenas itens públicos quando não logado
- [x] deve mostrar itens privados quando logado
- [x] não deve repetir itens na mesma página

### Revisor

- [ ] Funcionalidade verificada localmente
- [ ] Novos testes passam localmente e nos workflows
